### PR TITLE
refactor: extract a shared ProductImage component

### DIFF
--- a/src/app/sneakers/[id]/sneakersDetail.tsx
+++ b/src/app/sneakers/[id]/sneakersDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useCart } from '@/components/CartContext';
 import { Main } from '@/components/Main';
+import { ProductImage } from '@/components/ProductImage';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -14,7 +15,6 @@ import {
   ChevronLeft,
   Heart,
 } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -112,15 +112,11 @@ const DetailCard = ({
           </Link>
         </Button>
         <div className="grid grid-cols-1 gap-x-6 px-5 py-10 md:grid-cols-2">
-          <div className="flex h-[220px] items-center justify-center">
-            <Image
-              src={img}
-              width={350}
-              height={350}
-              alt="sneakers-preview"
-              className="-my-8 object-cover md:my-0"
-            />
-          </div>
+          <ProductImage
+            src={img}
+            alt="sneakers-preview"
+            className="h-[220px]"
+          />
 
           <div>
             <div className="text-sm uppercase text-muted-foreground">

--- a/src/components/CartCard.tsx
+++ b/src/components/CartCard.tsx
@@ -1,9 +1,9 @@
 import products from '@/assets/data.json';
 import { CartItem } from '@/lib/types';
 import { Trash, Trash2 } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 
+import { ProductImage } from './ProductImage';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 
@@ -20,14 +20,11 @@ export const CartCard = ({
 
   return (
     <Card key={item.id} className="bg-slate-100 p-4" role="listitem">
-      <div className="flex h-[150] items-center">
-        <Image
-          src={product.original_picture_url}
-          alt={product.name}
-          width={160}
-          height={160}
-        />
-      </div>
+      <ProductImage
+        src={product.original_picture_url}
+        alt={product.name}
+        className="h-[150px]"
+      />
 
       <h4 className="mb-2 font-semibold">{product.name}</h4>
       <div className="relative line-clamp-3 items-end text-sm">

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -2,8 +2,8 @@
 
 import { useCart } from '@/components/CartContext';
 import { Button } from '@/components/ui/button';
+import { ProductImage } from '@/components/ProductImage';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
-import Image from 'next/image';
 import Link from 'next/link';
 
 export type ProductCardProps = {
@@ -30,9 +30,7 @@ export const ProductCard = ({
 
   return (
     <Card className="w-72 bg-background hover:shadow-2xl">
-      <div className="flex h-[200px] items-center justify-center">
-        <Image src={img} alt={nickname} width={200} height={200} />
-      </div>
+      <ProductImage src={img} alt={nickname} className="h-[200px]" />
       <CardContent>
         <h3 className="text-mono truncate text-lg font-semibold tracking-tight">
           {nickname}

--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+import Image from 'next/image';
+
+/**
+ * Product picture, framed. Replaces the three near-identical image wrappers
+ * that lived in ProductCard, CartCard and the product detail page. Callers
+ * keep their own frame height through `className`.
+ */
+export const ProductImage = ({
+  src,
+  alt,
+  className,
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) => {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center overflow-hidden',
+        className,
+      )}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        width={400}
+        height={400}
+        className="h-full w-full object-cover"
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
`ProductCard`, `CartCard` and the product detail page each carried their own near-identical image wrapper. They now share a single `ProductImage` component, and each caller keeps its own frame height.

No visual change expected.