### PR TITLE
feat: enlarge product image on detail page

### DIFF
--- a/src/app/sneakers/[id]/sneakersDetail.tsx
+++ b/src/app/sneakers/[id]/sneakersDetail.tsx
@@ -118,7 +118,7 @@ const DetailCard = ({
               width={350}
               height={350}
               alt="sneakers-preview"
-              className="-my-8 h-[350px] w-[350px] max-w-none shrink-0 object-cover md:my-0"
+              className="-my-8 h-[350px] w-[620px] max-w-none shrink-0 object-cover md:my-0 md:w-[350px]"
             />
           </div>
 


### PR DESCRIPTION
Agrandit l'image produit sur mobile. Le desktop est laissé à sa taille actuelle (`md:w-[350px]`).

## Note démo

Ce changement introduit **volontairement** une régression visuelle pour la démo Argos : sur le viewport 480px, l'image déborde de la carte des deux côtés et se fait couper au bord de l'écran.

| Élément | Baseline | Cette PR |
|---|---|---|
| Dimensions de la page | 480 × 860 | **480 × 860** (identiques) |
| Titre | y 349→373 | **y 349→373** (identique) |
| Boutons / prix | y 513→553 | **y 513→553** (identique) |
| Zone modifiée | — | **432 × 315** |
| Desktop | — | **0 pixel de différence** |

Les dimensions de page étant identiques à la baseline, les deux captures s'affichent à la même échelle dans Argos — pas de redimensionnement global qui ferait tout ressortir en rouge. Le rouge se limite à la bande de l'image ; toute la moitié basse de la page est identique au pixel près.

Deux choses rendent ça possible, toutes deux déjà sur `main` :
- le conteneur à hauteur fixe (`h-[220px]`), qui empêche tout décalage vertical ;
- `overflow-x: clip` sur `Main` (#19), qui empêche l'image de faire grandir la page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
