### PR TITLE
fix: prevent horizontal page growth from overflowing content

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,3 +1,3 @@
 import { twx } from '@/lib/utils';
 
-export const Main = twx.div`max-w-screen-xl mx-auto pt-3 md:pt-16 pb-16`;
+export const Main = twx.div`max-w-screen-xl mx-auto overflow-x-clip pt-3 md:pt-16 pb-16`;


### PR DESCRIPTION
Empêche un enfant surdimensionné d'élargir la page et d'y introduire une barre de défilement horizontale, en clippant le débordement horizontal sur le wrapper `Main`.

## Pourquoi `clip` et pas `hidden`

`overflow-x: hidden` force l'autre axe en `auto` (règle CSS) : `Main` deviendrait un conteneur de défilement et **clipperait aussi verticalement**. Or l'image produit de la page détail déborde volontairement de son conteneur en hauteur — elle se serait retrouvée coupée. `overflow-x: clip` n'a pas cet effet de bord.

## Impact visuel

| Page | mobile 480 | desktop |
|---|---|---|
| homepage | 0 px | 0 px |
| sneakers-list | 0 px | 0 px |
| cart | 0 px | 0 px |
| sneakers-detail | sous le seuil | sous le seuil |

Sur la page détail, le clip change le contexte de composition, ce qui décale très légèrement le rééchantillonnage de l'image produit : **aucun pixel ne dépasse un delta de 8%** (écart de couleur max mesuré : 3,9%). Visuellement identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
