### PR TITLE
feat: align the add-to-cart action to the right

### DIFF
--- a/src/app/sneakers/[id]/sneakersDetail.tsx
+++ b/src/app/sneakers/[id]/sneakersDetail.tsx
@@ -146,8 +146,8 @@ const DetailCard = ({
             />
           </div>
 
-          <div className="mt-6 flex flex-wrap-reverse items-start justify-between gap-3 md:mt-0">
-            <div className="flex gap-1">
+          <div className="relative mt-6 flex flex-wrap-reverse items-start justify-end gap-3 md:mt-0">
+            <div className="absolute bottom-0 right-0 flex gap-1">
               {itemFromCart ? (
                 <Button
                   size="lg"


### PR DESCRIPTION
Pin the add-to-cart and wishlist buttons to the right edge of the action row, so the primary action sits where the eye lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CqLy22wYqrB7Q9v3a8xqS