### PR TITLE
feat: pin the price to the left of the action row

### DIFF
--- a/src/app/sneakers/[id]/sneakersDetail.tsx
+++ b/src/app/sneakers/[id]/sneakersDetail.tsx
@@ -146,7 +146,7 @@ const DetailCard = ({
             />
           </div>
 
-          <div className="mt-6 flex flex-wrap-reverse items-start justify-between gap-3 md:mt-0">
+          <div className="relative mt-6 flex flex-wrap-reverse items-start justify-between gap-3 md:mt-0">
             <div className="flex gap-1">
               {itemFromCart ? (
                 <Button
@@ -165,7 +165,7 @@ const DetailCard = ({
                 <Heart />
               </Button>
             </div>
-            <div className="pb-2 text-right text-2xl font-semibold">
+            <div className="absolute bottom-0 -left-6 pb-2 text-2xl font-semibold">
               ${price}
             </div>
           </div>


### PR DESCRIPTION
Take the price out of the flex row and anchor it to the bottom-left, so it reads next to the add-to-cart button rather than opposite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CqLy22wYqrB7Q9v3a8xqS